### PR TITLE
Removed all benchmark related logic in core

### DIFF
--- a/vectorq/__init__.py
+++ b/vectorq/__init__.py
@@ -12,7 +12,7 @@ from vectorq.inference_engine import (
     LangChainInferenceEngine,
     OpenAIInferenceEngine,
 )
-from vectorq.main import VectorQ, VectorQBenchmark
+from vectorq.main import VectorQ
 
 # Embedding engines
 from vectorq.vectorq_core.cache.embedding_engine import (
@@ -58,7 +58,6 @@ from vectorq.vectorq_core.vectorq_policy import (
 __all__ = [
     # Main classes
     "VectorQ",
-    "VectorQBenchmark",
     "VectorQConfig",
     # Inference engines
     "InferenceEngine",

--- a/vectorq/inference_engine/strategies/benchmark.py
+++ b/vectorq/inference_engine/strategies/benchmark.py
@@ -1,0 +1,27 @@
+from typing import override
+
+from vectorq.inference_engine.inference_engine import InferenceEngine
+
+
+class BenchmarkInferenceEngine(InferenceEngine):
+    """
+    An inference engine implementation that returns pre-computed responses for given prompts.
+    It is used for benchmarking purposes.
+    """
+
+    def __init__(self, prompt_response_map: dict[str, str]):
+        """
+        Initialize the benchmark engine with predefined responses.
+
+        Args:
+            prompt_response_map: A dictionary mapping prompts to their pre-computed responses.
+                                 Keys are prompt strings and values are response strings.
+        """
+        super().__init__()
+        self.prompt_response_map = prompt_response_map
+
+    @override
+    def create(self, prompt: str, system_prompt: str = None) -> str:
+        if prompt not in self.prompt_response_map:
+            raise ValueError(f"Prompt {prompt} not found in prompt_response_map")
+        return self.prompt_response_map[prompt]

--- a/vectorq/main.py
+++ b/vectorq/main.py
@@ -5,16 +5,6 @@ from vectorq.inference_engine.inference_engine import InferenceEngine
 from vectorq.vectorq_core.core import VectorQCore
 
 
-class VectorQBenchmark:
-    def __init__(
-        self,
-        candidate_embedding: List[float],
-        candidate_response: str,
-    ):
-        self.candidate_embedding = candidate_embedding
-        self.candidate_response = candidate_response
-
-
 class VectorQ:
     """
     VectorQ is a main class that contains the VectorQ semantic prompt caching system.
@@ -34,21 +24,18 @@ class VectorQ:
         self,
         prompt: str,
         system_prompt: Optional[str] = None,
-        benchmark: Optional[VectorQBenchmark] = None,
     ) -> Tuple[bool, str, str]:
         """
         prompt: str - The prompt to create a response for.
-        system_prompt: str - The optional system prompt to use for the response. It will override the system prompt in the VectorQConfig if provided.
-        benchmark: VectorQBenchmark - The optional benchmark object containing the pre-computed embedding and response.
+        system_prompt: Optional[str] - The optional system prompt to use for the response. It will override the system prompt in the VectorQConfig if provided.
         Returns: Tuple[bool, str, str] - [is_cache_hit, actual_response, nn_response] (the actual response is the one supposed to be used by the user, the nn_response is for benchmarking purposes)
         """
+        # Override system prompt if provided
         if system_prompt is None:
             system_prompt = self.vectorq_config.system_prompt
+
         if self.vectorq_config.enable_cache:
-            is_cache_hit, actual_response, nn_response = self.core.process_request(
-                prompt, benchmark, system_prompt
-            )
-            return is_cache_hit, actual_response, nn_response
+            return self.core.process_request(prompt, system_prompt)
         else:
             response = self.inference_engine.create(prompt, system_prompt)
             return False, response, response

--- a/vectorq/vectorq_core/cache/cache.py
+++ b/vectorq/vectorq_core/cache/cache.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import List
 
 from vectorq.vectorq_core.cache.embedding_engine.embedding_engine import EmbeddingEngine
 from vectorq.vectorq_core.cache.embedding_store.embedding_metadata_storage.embedding_metadata_obj import (
@@ -6,9 +6,6 @@ from vectorq.vectorq_core.cache.embedding_store.embedding_metadata_storage.embed
 )
 from vectorq.vectorq_core.cache.embedding_store.embedding_store import EmbeddingStore
 from vectorq.vectorq_core.cache.eviction_policy.eviction_policy import EvictionPolicy
-
-if TYPE_CHECKING:
-    from vectorq.main import VectorQBenchmark
 
 
 class Cache:
@@ -31,14 +28,6 @@ class Cache:
         embedding = self.embedding_engine.get_embedding(prompt)
         self.embedding_store.add_embedding(embedding, response)
 
-    def add_embedding(self, embedding: List[float], response: str) -> int:
-        """
-        embedding: List[float] - The embedding to add to the cache
-        response: str - The response to add to the cache
-        returns: int - The id of the embedding
-        """
-        self.embedding_store.add_embedding(embedding, response)
-
     def remove(self, embedding_id: int) -> int:
         """
         embedding_id: int - The id of the embedding to remove
@@ -46,18 +35,13 @@ class Cache:
         """
         self.embedding_store.remove(embedding_id)
 
-    def get_knn(
-        self, prompt: str, k: int, benchmark: Optional["VectorQBenchmark"]
-    ) -> List[tuple[float, int]]:
+    def get_knn(self, prompt: str, k: int) -> List[tuple[float, int]]:
         """
         prompt: str - The prompt to get the k-nearest neighbors for
         k: int - The number of nearest neighbors to get
         returns: List[tuple[float, int]] - A list of tuples, each containing a similarity score and an embedding id
         """
-        if benchmark is not None:
-            embedding: List[float] = benchmark.candidate_embedding
-        else:
-            embedding: List[float] = self.embedding_engine.get_embedding(prompt)
+        embedding = self.embedding_engine.get_embedding(prompt)
         return self.embedding_store.get_knn(embedding, k)
 
     def flush(self) -> None:
@@ -66,7 +50,7 @@ class Cache:
         """
         self.embedding_store.reset()
 
-    def get_metadata(self, embedding_id: int) -> "EmbeddingMetadataObj":
+    def get_metadata(self, embedding_id: int) -> EmbeddingMetadataObj:
         """
         embedding_id: int - The id of the embedding to get the metadata for
         returns: EmbeddingMetadataObj - The metadata of the embedding
@@ -74,8 +58,8 @@ class Cache:
         return self.embedding_store.get_metadata(embedding_id)
 
     def update_metadata(
-        self, embedding_id: int, embedding_metadata: "EmbeddingMetadataObj"
-    ) -> "EmbeddingMetadataObj":
+        self, embedding_id: int, embedding_metadata: EmbeddingMetadataObj
+    ) -> EmbeddingMetadataObj:
         """
         embedding_id: int - The id of the embedding to update
         embedding_metadata: EmbeddingMetadataObj - The metadata to update the embedding with
@@ -96,7 +80,7 @@ class Cache:
         """
         return self.embedding_store.is_empty()
 
-    def get_all_embedding_metadata_objects(self) -> List["EmbeddingMetadataObj"]:
+    def get_all_embedding_metadata_objects(self) -> List[EmbeddingMetadataObj]:
         """
         returns: List["EmbeddingMetadataObj"] - A list of all the embedding metadata objects in the cache
         """

--- a/vectorq/vectorq_core/cache/embedding_engine/strategies/benchmark.py
+++ b/vectorq/vectorq_core/cache/embedding_engine/strategies/benchmark.py
@@ -1,0 +1,27 @@
+from typing import Dict, List, override
+
+from vectorq.vectorq_core.cache.embedding_engine.embedding_engine import EmbeddingEngine
+
+
+class BenchmarkEmbeddingEngine(EmbeddingEngine):
+    """
+    An embedding engine implementation that returns pre-computed embeddings for given texts.
+    It is used for benchmarking purposes.
+    """
+
+    def __init__(self, text_embedding_map: Dict[str, List[float]]):
+        """
+        Initialize the benchmark embedding engine with predefined embeddings.
+
+        Args:
+            text_embedding_map: A dictionary mapping text strings to their pre-computed embeddings.
+                               Keys are text strings and values are embedding vectors.
+        """
+        super().__init__()
+        self.text_embedding_map = text_embedding_map
+
+    @override
+    def get_embedding(self, text: str) -> List[float]:
+        if text not in self.text_embedding_map:
+            raise ValueError(f"Text '{text}' not found in text_embedding_map")
+        return self.text_embedding_map[text]


### PR DESCRIPTION
# Overview

Removed all benchmark related logic in vector core package

## Why
Previously, there are `benchmark` parameters in many functions for precomputed embeddings and inference response, which adds complexity to the core logic that are not related to normal users.

## Changes
- Removed `VectorQBenchmark` class
- Created `InferenceEngine` and `EmbeddingEngine` classes that are dedicated for benchmark use
- Simplified core logic by moving `benchmark` params

## Usage Example

### Before
```python
# Using with benchmark
benchmark = VectorQBenchmark(
    candidate_embedding=[0.1, 0.2, 0.3],
    candidate_response="Paris"
)
is_cache_hit, response, nn_response = vectorq.create(
    prompt="What is the capital of France?",
    benchmark=benchmark
)
```

### After
```python
# Use the dedicated engine classes in VectorQ configs
benchmark_inference = BenchmarkInferenceEngine(
    prompt_response_map={"What is the capital of France?": "Paris"}
)
benchmark_embeddings = BenchmarkEmbeddingEngine(
    text_embedding_map={"What is the capital of France?": [0.1, 0.2, 0.3]}
)

# Clean simple API
is_cache_hit, response, nn_response = vectorq.create(
    prompt="What is the capital of France?",
)
```

## Notes

I haven't changed the code in `benchmark/benchmark.py` yet, since @luis-gasparschroeder is working on it on other branches
