### PR TITLE
feat: Add LFU Eviction Policy with LRU tie-breaking

### DIFF
--- a/tests/test_lfu_eviction_policy.py
+++ b/tests/test_lfu_eviction_policy.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for LFUEvictionPolicy.
+Run with: pytest tests/test_lfu_eviction_policy.py -v
+"""
+import sys
+import types
+from datetime import datetime, timezone, timedelta
+
+for _n in ["vllm", "vllm.config", "vllm.entrypoints", "vllm.entrypoints.llm",
+           "vllm.platforms", "vllm.platforms.cuda", "vllm.utils"]:
+    sys.modules.setdefault(_n, types.ModuleType(_n))
+
+import pytest
+from vcache.vcache_core.cache.embedding_store.embedding_metadata_storage.embedding_metadata_obj import EmbeddingMetadataObj
+from vcache.vcache_core.cache.eviction_policy.lfu_eviction_policy import LFUEvictionPolicy
+
+
+def make_meta(embedding_id, access_count=0, last_accessed=None):
+    m = EmbeddingMetadataObj(embedding_id=embedding_id, response="r")
+    m.access_count = access_count
+    m.last_accessed = last_accessed or datetime.min.replace(tzinfo=timezone.utc)
+    return m
+
+
+class TestConstruction:
+    def test_custom_max_size(self):
+        p = LFUEvictionPolicy(max_size=500)
+        assert p.max_size == 500
+
+    def test_default_watermark(self):
+        p = LFUEvictionPolicy(max_size=100)
+        assert p.watermark == 0.95
+
+    def test_custom_params(self):
+        p = LFUEvictionPolicy(max_size=500, watermark=0.8, eviction_percentage=0.2)
+        assert p.eviction_percentage == 0.2
+
+    def test_str_contains_class_name(self):
+        assert "LFUEvictionPolicy" in str(LFUEvictionPolicy(max_size=10))
+
+
+class TestUpdateEvictionMetadata:
+    def test_first_access_sets_count_to_1(self):
+        p = LFUEvictionPolicy(max_size=100)
+        m = EmbeddingMetadataObj(embedding_id=1, response="r")
+        p.update_eviction_metadata(m)
+        assert m.access_count == 1
+
+    def test_repeated_access_increments(self):
+        p = LFUEvictionPolicy(max_size=100)
+        m = EmbeddingMetadataObj(embedding_id=1, response="r")
+        for _ in range(5):
+            p.update_eviction_metadata(m)
+        assert m.access_count == 5
+
+    def test_updates_last_accessed(self):
+        p = LFUEvictionPolicy(max_size=100)
+        m = EmbeddingMetadataObj(embedding_id=1, response="r")
+        before = datetime.now(timezone.utc)
+        p.update_eviction_metadata(m)
+        assert m.last_accessed >= before
+
+    def test_access_count_starts_from_zero(self):
+        p = LFUEvictionPolicy(max_size=100)
+        m = EmbeddingMetadataObj(embedding_id=1, response="r")
+        p.update_eviction_metadata(m)
+        p.update_eviction_metadata(m)
+        assert m.access_count == 2
+
+
+class TestSelectVictims:
+    def test_empty_returns_empty(self):
+        p = LFUEvictionPolicy(max_size=100)
+        assert p.select_victims([]) == []
+
+    def test_evicts_least_frequent(self):
+        p = LFUEvictionPolicy(max_size=100, eviction_percentage=0.1)
+        metadata = [make_meta(i, access_count=i) for i in range(20)]
+        victims = p.select_victims(metadata)
+        assert set(victims) == set(range(10))
+
+    def test_lru_tiebreak(self):
+        p = LFUEvictionPolicy(max_size=10, eviction_percentage=0.1)
+        now = datetime.now(timezone.utc)
+        old = make_meta(1, access_count=1, last_accessed=now - timedelta(hours=2))
+        new = make_meta(2, access_count=1, last_accessed=now)
+        victims = p.select_victims([old, new])
+        assert 1 in victims
+
+    def test_never_accessed_evicted_first(self):
+        p = LFUEvictionPolicy(max_size=10, eviction_percentage=0.1)
+        cold = make_meta(1, access_count=0)
+        hot  = make_meta(2, access_count=99)
+        victims = p.select_victims([cold, hot])
+        assert 1 in victims
+        assert 2 not in victims
+
+    def test_high_frequency_survives(self):
+        p = LFUEvictionPolicy(max_size=100, eviction_percentage=0.1)
+        popular = make_meta(999, access_count=1000)
+        cold = [make_meta(i, access_count=0) for i in range(20)]
+        victims = p.select_victims(cold + [popular])
+        assert 999 not in victims
+
+    def test_num_victims_respects_eviction_percentage(self):
+        p = LFUEvictionPolicy(max_size=100, eviction_percentage=0.2)
+        metadata = [make_meta(i) for i in range(50)]
+        victims = p.select_victims(metadata)
+        assert len(victims) == 20
+
+    def test_returns_embedding_ids(self):
+        p = LFUEvictionPolicy(max_size=10, eviction_percentage=0.1)
+        metadata = [make_meta(i) for i in range(10)]
+        victims = p.select_victims(metadata)
+        assert all(isinstance(v, int) for v in victims)
+
+    def test_update_then_select_keeps_hot_entry(self):
+        p = LFUEvictionPolicy(max_size=100, eviction_percentage=0.1)
+        hot = EmbeddingMetadataObj(embedding_id=99, response="r")
+        for _ in range(50):
+            p.update_eviction_metadata(hot)
+        cold = [make_meta(i, access_count=0) for i in range(20)]
+        victims = p.select_victims(cold + [hot])
+        assert 99 not in victims

--- a/vcache/vcache_core/cache/eviction_policy/__init__.py
+++ b/vcache/vcache_core/cache/eviction_policy/__init__.py
@@ -14,4 +14,6 @@ __all__ = [
     "NoEvictionPolicy",
     "EvictionPolicy",
     "SCUEvictionPolicy",
+    "LFUEvictionPolicy",
 ]
+from vcache.vcache_core.cache.eviction_policy.lfu_eviction_policy import LFUEvictionPolicy

--- a/vcache/vcache_core/cache/eviction_policy/lfu_eviction_policy.py
+++ b/vcache/vcache_core/cache/eviction_policy/lfu_eviction_policy.py
@@ -1,0 +1,87 @@
+"""
+Least Frequently Used (LFU) Eviction Policy for vCache.
+
+Tracks access frequency per cache entry and evicts the least frequently
+used entries when the cache exceeds its watermark threshold.
+Ties in frequency are broken by recency (LRU tie-breaking via last_accessed).
+"""
+
+from __future__ import annotations
+
+import heapq
+from datetime import datetime, timezone
+from typing import List
+
+from vcache.vcache_core.cache.embedding_store.embedding_metadata_storage.embedding_metadata_obj import (
+    EmbeddingMetadataObj,
+)
+from vcache.vcache_core.cache.eviction_policy.eviction_policy import EvictionPolicy
+
+
+class LFUEvictionPolicy(EvictionPolicy):
+    """
+    Least Frequently Used (LFU) eviction policy with LRU tie-breaking.
+
+    Tracks access_count per entry. Evicts lowest-frequency entries first.
+    Ties broken by last_accessed (oldest evicted first).
+
+    Args:
+        max_size (int): Maximum number of entries before eviction triggers.
+        watermark (float): Fraction of max_size that triggers eviction.
+        eviction_percentage (float): Fraction of max_size to evict per cycle.
+    """
+
+    _MIN_DATETIME: datetime = datetime.min.replace(tzinfo=timezone.utc)
+
+    def __init__(
+        self, max_size: int, watermark: float = 0.95, eviction_percentage: float = 0.1
+    ):
+        super().__init__(
+            max_size=max_size,
+            watermark=watermark,
+            eviction_percentage=eviction_percentage,
+        )
+
+    def update_eviction_metadata(self, metadata: EmbeddingMetadataObj) -> None:
+        """
+        Increment access_count and refresh last_accessed on cache hit.
+
+        Args:
+            metadata: The metadata object of the accessed cache entry.
+        """
+        metadata.access_count = getattr(metadata, "access_count", 0) + 1
+        metadata.last_accessed = datetime.now(timezone.utc)
+
+    def select_victims(self, all_metadata: List[EmbeddingMetadataObj]) -> List[int]:
+        """
+        Select least frequently used entries for eviction.
+
+        Sorts by (access_count ASC, last_accessed ASC) and returns
+        eviction_percentage * max_size entries.
+
+        Args:
+            all_metadata: All metadata objects in the cache.
+
+        Returns:
+            List of embedding_ids to evict.
+        """
+        num_to_evict: int = int(self.max_size * self.eviction_percentage)
+        if num_to_evict == 0 or not all_metadata:
+            return []
+
+        victims_metadata: List[EmbeddingMetadataObj] = heapq.nsmallest(
+            num_to_evict,
+            all_metadata,
+            key=lambda m: (
+                getattr(m, "access_count", 0),
+                m.last_accessed if m.last_accessed is not None else self._MIN_DATETIME,
+            ),
+        )
+        return [m.embedding_id for m in victims_metadata]
+
+    def __str__(self) -> str:
+        return (
+            f"LFUEvictionPolicy(max_size={self.max_size}, "
+            f"watermark={self.watermark}, "
+            f"eviction_percentage={self.eviction_percentage})"
+        )


### PR DESCRIPTION
## Summary
This PR adds LFUEvictionPolicy to vCache.

## Motivation
Existing policies are recency-based. LFU retains high-value entries regardless of recency, improving hit rates on skewed workloads.

## Changes
- New: lfu_eviction_policy.py
- New: tests/test_lfu_eviction_policy.py — 16 tests passing
- Updated __init__.py

## Tests
pytest tests/test_lfu_eviction_policy.py -v  # 16 passed