### PR TITLE
Isolate eviction and Chroma tests from external state

### DIFF
--- a/tests/integration/test_eviction_policy.py
+++ b/tests/integration/test_eviction_policy.py
@@ -165,10 +165,17 @@ class TestEvictionPolicy(unittest.TestCase):
             time.sleep(1)
             return original_evict_victims(*args, **kwargs)
 
-        with patch.object(
-            self.vcache.vcache_config.eviction_policy,
-            "_evict_victims",
-            side_effect=slow_evict_victims,
+        with (
+            patch.object(
+                self.vcache.vcache_config.eviction_policy,
+                "_evict_victims",
+                side_effect=slow_evict_victims,
+            ),
+            patch.object(
+                self.vcache.vcache_policy.inference_engine,
+                "create",
+                return_value="mock response",
+            ),
         ):
             # Fill the cache up to just before the watermark limit
             for i in range(self.watermark_limit - 1):

--- a/vcache/vcache_core/cache/embedding_store/vector_db/strategies/chroma.py
+++ b/vcache/vcache_core/cache/embedding_store/vector_db/strategies/chroma.py
@@ -1,4 +1,5 @@
 from typing import List
+from uuid import uuid4
 
 import chromadb
 
@@ -110,7 +111,7 @@ class ChromaVectorDB(VectorDB):
             ValueError: If the similarity metric type is invalid.
         """
         self.client = chromadb.Client()
-        collection_name = f"vcache_collection_{id(self)}"
+        collection_name: str = f"vcache_collection_{uuid4().hex}"
         metric_type = self.similarity_metric_type.value
         match metric_type:
             case "cosine":
@@ -122,7 +123,7 @@ class ChromaVectorDB(VectorDB):
         self.collection = self.client.create_collection(
             name=collection_name,
             metadata={"dimension": embedding_dim, "hnsw:space": space},
-            get_or_create=True,
+            get_or_create=False,
         )
 
     def is_empty(self) -> bool:


### PR DESCRIPTION
## Summary
- mock inference in the eviction concurrency test so fork PRs do not need an OpenAI secret
- assign UUID-based names to ephemeral Chroma collections
- disable Chroma collection reuse to prevent stale data leaking between tests
